### PR TITLE
Bluntly fixes caching issues

### DIFF
--- a/server/compiler.js
+++ b/server/compiler.js
@@ -77,6 +77,51 @@ function createCompiler(file, type) {
 
 /**
 
+  Pulls data from cookies, session, params, query, slug and metadata into
+  single data object.
+
+  @param {Request} req Express request
+  @param {Response} res Express response
+  @param {Object} metadata Metadata object as returns by metadata.js
+  @returns {Object} The data object
+
+**/
+
+function aggregateData(req, res, metadata) {
+
+  // Data object will include locals, cookies, session, params, query, slug
+  // and if applicable, database query results
+  var data = Object.assign({}, global.locals, res.locals);
+
+  // Attach special variables
+  data.$cookies = req.cookies;
+  data.$session = req.session;
+  data.$params  = req.params;
+  data.$query   = req.query;
+
+  // Special slug
+  if (metadata.isTemplate)
+    data.$slug = req.url.replace(req.route.path.split(":")[0], "");
+
+  // Set cookies
+  for (var key in metadata.cookies || {}) {
+    res.cookie(key, metadata.cookies[key]);
+    data.$cookies[key] = metadata.cookies[key];
+  }
+
+  // Set session
+  for (key in metadata.session || {}) {
+    req.session[key] = metadata.session[key];
+    data.$session[key] = metadata.session[key];
+  }
+
+  return data;
+
+}
+
+
+/**
+
   Creates a route handler for a file
 
   @param {File} file File information provided by Utils.parse
@@ -104,39 +149,9 @@ function createHandler(file, type, compiler, metadata) {
   return function(req, res, next) {
 
     // Note that the BrowserSync proxy always sets method to identity
-    var data = {},
-        compiled,
+    var compiled,
+        data = isHTML ? aggregateData(req, res, metadata) : {},
         method = req.acceptsEncodings(["gzip", "deflate", "identity"]) || "identity";
-
-    if (isHTML) {
-
-      // Data object will include locals, cookies, session, params, query, slug
-      // and if applicable, database query results
-      data = Object.assign(data, global.locals, res.locals);
-
-      // Attach special variables
-      data.$cookies = req.cookies;
-      data.$session = req.session;
-      data.$params  = req.params;
-      data.$query   = req.query;
-
-      // Special slug
-      if (metadata.isTemplate)
-        data.$slug = req.url.replace(req.route.path.split(":")[0], "");
-
-      // Set cookies
-      for (key in metadata.cookies || {}) {
-        res.cookie(key, metadata.cookies[key]);
-        data.$cookies[key] = metadata.cookies[key];
-      }
-
-      // Set session
-      for (key in metadata.session || {}) {
-        req.session[key] = metadata.session[key];
-        data.$session[key] = metadata.session[key];
-      }
-
-    }
 
     // We are currently assuming a synchronous, non-shared cache. This should
     // help with performance.

--- a/server/compiler.js
+++ b/server/compiler.js
@@ -153,9 +153,11 @@ function createHandler(file, type, compiler, metadata) {
         data = isHTML ? aggregateData(req, res, metadata) : {},
         method = req.acceptsEncodings(["gzip", "deflate", "identity"]) || "identity";
 
-    // We are currently assuming a synchronous, non-shared cache. This should
-    // help with performance.
-    if (cache && (compiled = Cache.get(method + ":" + file.path))) {
+    // We are currently assuming a synchronous, non-shared cache. Note that we are currently using
+    // req.url. We should eventually offer much more granular caching options. This will currently
+    // store multiple copies of the same object in the event that the underlying file served is the
+    // same but the path is different.
+
     if (cache && (compiled = Cache.get(method + ":" + req.url))) {
       Utils.send(res, type, compiled, method, CACHE_MS);
       return;

--- a/server/compiler.js
+++ b/server/compiler.js
@@ -156,6 +156,7 @@ function createHandler(file, type, compiler, metadata) {
     // We are currently assuming a synchronous, non-shared cache. This should
     // help with performance.
     if (cache && (compiled = Cache.get(method + ":" + file.path))) {
+    if (cache && (compiled = Cache.get(method + ":" + req.url))) {
       Utils.send(res, type, compiled, method, CACHE_MS);
       return;
     }
@@ -165,7 +166,7 @@ function createHandler(file, type, compiler, metadata) {
       var level;
 
       // Cache raw results
-      if (cache) Cache.set("identity:" + file.path, compiled);
+      if (cache) Cache.set("identity:" + req.url, compiled);
 
       // Uncompressed
       if ("identity" === method) return Utils.send(res, type, compiled, method, CACHE_MS);
@@ -178,7 +179,7 @@ function createHandler(file, type, compiler, metadata) {
 
         // Send and cache results: should we cache original results too?
         Utils.send(res, type, compressed, method, CACHE_MS);
-        if (cache) Cache.set(method + ":" + file.path, compressed);
+        if (cache) Cache.set(method + ":" + req.url, compressed);
 
       });
 

--- a/server/globals.js
+++ b/server/globals.js
@@ -34,7 +34,7 @@ module.exports = function(options) {
     global.ports = { server : 27182 };
     global.server = require("browser-sync").create();
   } else {
-    global.ports = { server : global.config.port || 3000 };
+    global.ports = { server : global.config.port || process.env.PORT || 3000 };
   }
 
   // Pipelines


### PR DESCRIPTION
Previously, templated pages were being incorrectly cached. We move towards an inefficient caching mechanism as a functional safeguard until more granular solutions are implemented.
